### PR TITLE
Fix failing tests

### DIFF
--- a/src/test/java/com/westudio/java/etcd/EtcdCADTest.java
+++ b/src/test/java/com/westudio/java/etcd/EtcdCADTest.java
@@ -29,8 +29,13 @@ public class EtcdCADTest {
 
         Map<String, String> params = new HashMap<String, String>();
         params.put("prevValue", "world");
-        result = this.client.cad(key, params);
-        Assert.assertEquals(true, result.isError());
+        try{
+            this.client.cad(key, params);
+            Assert.fail();
+        } catch (EtcdClientException e) {
+            Assert.assertTrue(e.isEtcdError());
+        }
+
         result = this.client.get(key);
         Assert.assertEquals("hello", result.node.value);
         params.clear();

--- a/src/test/java/com/westudio/java/etcd/EtcdCASTest.java
+++ b/src/test/java/com/westudio/java/etcd/EtcdCASTest.java
@@ -32,8 +32,14 @@ public class EtcdCASTest {
 
         Map<String, String> params = new HashMap<String, String>();
         params.put("prevExist", String.valueOf(false));
-        result = this.client.cas(key, "world", params);
-        Assert.assertEquals(true, result.isError());
+
+        try {
+            this.client.cas(key, "world", params);
+            Assert.fail();
+        } catch (EtcdClientException e) {
+            Assert.assertTrue(e.isEtcdError());
+        }
+
         result = this.client.get(key);
         Assert.assertEquals("hello", result.node.value);
 

--- a/src/test/java/com/westudio/java/etcd/EtcdInOrderTest.java
+++ b/src/test/java/com/westudio/java/etcd/EtcdInOrderTest.java
@@ -22,6 +22,9 @@ public class EtcdInOrderTest {
 
         EtcdResponse result;
 
+        result = this.client.deleteDir(key, true);
+        Assert.assertEquals("delete", result.action);
+
         result = this.client.inOrderKeys(key, "Job1");
         Assert.assertEquals(result.node.value, "Job1");
         int k1 = Integer.valueOf(result.node.key.substring(result.node.key.lastIndexOf("/") + 1));


### PR DESCRIPTION
The CAS/CAD tests failed due to exceptions being thrown instead of an etcd error response being returned.

Not sure if throwing exceptions is the expected behaviour here. But since many of the other tests asserted that `EtcdClientException` are thrown, I assumed this is the right thing to do.
