### PR TITLE
fix index overflow

### DIFF
--- a/src/main/java/com/xqbase/etcd4j/EtcdResult.java
+++ b/src/main/java/com/xqbase/etcd4j/EtcdResult.java
@@ -11,7 +11,7 @@ public class EtcdResult {
     public int errorCode;
     public String message;
     public String cause;
-    public int index;
+    public long index;
 
     public boolean isError() {
         return errorCode != 0;


### PR DESCRIPTION
in etcd [doc](https://coreos.com/etcd/docs/latest/v2/api.html#waiting-for-a-change)
If we miss all the 1000 events, we need to recover the current state of the watching key space through a get and then start to watch from the X-Etcd-Index + 1.

For example, we set /other="bar" for 2000 times and try to wait from index 8.
```
curl 'http://127.0.0.1:2379/v2/keys/foo?wait=true&waitIndex=8'
```
We get the index is outdated response, since we miss the 1000 events kept in etcd.

```
{"errorCode":401,"message":"The event in requested index is outdated and cleared","cause":"the requested history has been cleared [1008/8]","index":2007}
```

The index is a long type, when index is bigger than 2,147,483,647(2^31 - 1) gson will throw an NumberFormatException.